### PR TITLE
Async Compress Image

### DIFF
--- a/ShareManager/Core/SMImage.m
+++ b/ShareManager/Core/SMImage.m
@@ -14,8 +14,10 @@
 {
     self = [super init];
     if (self) {
-        _compressedData = UIImageJPEGRepresentation([UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:imageUrl]]], 0.3);
-        _compressedImage = [UIImage imageWithData:_compressedData];
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            _compressedData = UIImageJPEGRepresentation([UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:imageUrl]]], 0.3);
+            _compressedImage = [UIImage imageWithData:_compressedData];
+        });
     }
     return self;
 }


### PR DESCRIPTION
异步普通线程压缩图片，当分享的原图较大时，能明显减少分享UI视图弹出的延迟
